### PR TITLE
fix!: include key when making unique identifier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     hooks:
       - id: typos
   - repo: https://github.com/tombi-toml/tombi-pre-commit
-    rev: v1.4.0
+    rev: v1.4.1
     hooks:
       - id: tombi-format
         exclude: ".*\\.lock"

--- a/src/rawxio/rawx.py
+++ b/src/rawxio/rawx.py
@@ -64,7 +64,9 @@ def read_rawx(fname: Path, encoding: str | None = None) -> dict[str, pd.DataFram
             # The frame has primary keys. We produce a hash value to use for index based
             # on the primary keys
             pk_fields = list(set(get_pk_fields(key)).intersection(df.columns))
-            index = [uuid(t) for t in df[sorted(pk_fields)].itertuples(name=None, index=False)]
+            index = [
+                uuid((key, *t)) for t in df[sorted(pk_fields)].itertuples(name=None, index=False)
+            ]
             df = df.set_index(pd.Index(index, name="uid"))
         result[key] = df
     return result


### PR DESCRIPTION
This is done to distinguish between different components (load/gen) on the same node.